### PR TITLE
Multi-Profile Support for Feelfit Integration

### DIFF
--- a/custom_components/feelfit/__init__.py
+++ b/custom_components/feelfit/__init__.py
@@ -1,61 +1,135 @@
+"""The Feelfit integration."""
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
 from .api import FeelfitApi, FeelfitApiError
+from .const import CONF_SELECTED_PROFILES, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger("custom_components.feelfit")
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Feelfit from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    email = entry.data.get("email")
-    token = entry.data.get("token")
-    saved_user_info = entry.data.get("user_info") or {}
+    email: str | None = entry.data.get("email")
+    token: str | None = entry.data.get("token")
+    saved_user_info: dict[str, Any] = entry.data.get("user_info") or {}
+
+    selected_profiles: list[str] = (
+        entry.options.get(CONF_SELECTED_PROFILES) or
+        entry.data.get(CONF_SELECTED_PROFILES) or
+        []
+    )
+
+    if not email:
+        _LOGGER.error("No email found in config entry")
+        return False
 
     session = async_get_clientsession(hass)
     api = FeelfitApi(hass, session, email)
 
-    # restore token and user_info if present in entry.data (from config flow)
     if token:
         api.token = token
     if saved_user_info:
         api.user_info = saved_user_info
 
-    # store api and initial user_info; will be refreshed by sensor coordinator
-    hass.data[DOMAIN][entry.entry_id] = {"api": api, "user_info": api.user_info}
+    hass.data[DOMAIN][entry.entry_id] = {
+        "api": api,
+        "user_info": api.user_info,
+        "selected_profiles": selected_profiles,
+    }
 
-    # try an initial fetch to populate user_settings/goals/device_binds so sensors aren't empty
     try:
-        user_id = api.user_info.get("user_id") if api.user_info else entry.unique_id or entry.entry_id
-        if api.token:
-            payload = await api.async_fetch_all(str(user_id))
-            # update stored values
-            hass.data[DOMAIN][entry.entry_id]["user_info"] = payload.get("user_info") or api.user_info
-            hass.data[DOMAIN][entry.entry_id]["user_settings"] = payload.get("user_settings") or {}
-            hass.data[DOMAIN][entry.entry_id]["goals"] = payload.get("goals") or {}
-            hass.data[DOMAIN][entry.entry_id]["device_binds"] = payload.get("device_binds") or {}
+        user_id = (
+            api.user_info.get("user_id")
+            if api.user_info
+            else entry.unique_id or entry.entry_id
+        )
+        if api.token and user_id:
+            payload = await api.async_fetch_all(
+                str(user_id),
+                selected_profiles=selected_profiles if selected_profiles else None
+            )
+            hass.data[DOMAIN][entry.entry_id].update({
+                "profiles": payload.get("profiles") or [],
+                "device_binds": payload.get("device_binds") or {},
+            })
     except FeelfitApiError as err:
         _LOGGER.debug("Initial fetch failed (will retry via coordinator): %s", err)
-    except Exception as err:  # be defensive
+    except Exception as err:
         _LOGGER.exception("Unexpected error during initial Feelfit fetch: %s", err)
 
-    # forward platform setup
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     return True
 
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update - rimuove entità e device dei profili disattivati."""
+    from homeassistant.helpers import entity_registry as er, device_registry as dr
+
+    new_selected = entry.options.get(CONF_SELECTED_PROFILES, [])
+    old_selected = entry.data.get(CONF_SELECTED_PROFILES, [])
+
+    removed_profiles = set(old_selected) - set(new_selected)
+
+    if removed_profiles:
+        _LOGGER.debug("Removing entities for deselected profiles: %s", removed_profiles)
+
+        entity_registry = er.async_get(hass)
+        device_registry = dr.async_get(hass)
+
+        devices_to_remove = []
+        for device_entry in device_registry.devices.values():
+
+            for identifier_tuple in device_entry.identifiers:
+                if identifier_tuple[0] == DOMAIN:
+                    device_id_str = identifier_tuple[1]
+
+                    if device_id_str.startswith("user_"):
+                        user_id = device_id_str.replace("user_", "")
+                        if user_id in removed_profiles:
+                            devices_to_remove.append(device_entry.id)
+                            _LOGGER.debug("Found device to remove: %s (user_id: %s)",
+                                        device_entry.name, user_id)
+                            break
+
+        for device_id in devices_to_remove:
+            device_registry.async_remove_device(device_id)
+            _LOGGER.info("Removed device: %s", device_id)
+
+        if devices_to_remove:
+            _LOGGER.info("Removed %d devices for deselected profiles", len(devices_to_remove))
+        else:
+
+            entries_to_remove = []
+            for entity_entry in entity_registry.entities.values():
+                if entity_entry.config_entry_id == entry.entry_id:
+
+                    for removed_user_id in removed_profiles:
+                        if str(removed_user_id) in entity_entry.unique_id:
+                            entries_to_remove.append(entity_entry.entity_id)
+                            _LOGGER.debug("Removing entity: %s", entity_entry.entity_id)
+                            break
+
+            for entity_id in entries_to_remove:
+                entity_registry.async_remove(entity_id)
+
+            if entries_to_remove:
+                _LOGGER.info("Removed %d entities for deselected profiles", len(entries_to_remove))
+
+    await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor"])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unload_ok

--- a/custom_components/feelfit/api.py
+++ b/custom_components/feelfit/api.py
@@ -1,75 +1,79 @@
+"""API client for Feelfit integration."""
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import logging
 import time
 import urllib.parse
-from typing import Any, Dict, Optional
+from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
 from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
-import asyncio
 
 from .const import (
     API_BASE,
-    DEFAULT_QUERY_PARAMS,
-    PATH_LOGIN,
-    PATH_USER_SETTINGS,
-    PATH_GOALS,
-    PATH_DEVICE_BINDS,
-    PATH_MEASUREMENTS,
-    PATH_GET_PRIMARY_USER,
-    LOGIN_HEADERS,
     COMMON_HEADERS,
+    DEFAULT_QUERY_PARAMS,
+    LOGIN_HEADERS,
+    PATH_DEVICE_BINDS,
+    PATH_GET_PRIMARY_USER,
+    PATH_GOALS,
+    PATH_LOGIN,
+    PATH_MEASUREMENTS,
+    PATH_USER_SETTINGS,
     PUBLIC_KEY,
 )
 
 _LOGGER = logging.getLogger("custom_components.feelfit.api")
 
-
 class FeelfitApiError(Exception):
-    pass
-
+    """Exception for Feelfit API errors."""
 
 class FeelfitApi:
     """API client for Feelfit with incremental measurement fetching."""
 
-    def __init__(self, hass, session: ClientSession, email: str) -> None:
+    def __init__(self, hass: Any, session: ClientSession, email: str) -> None:
+        """Initialize the API client."""
         self.hass = hass
         self._session = session
         self.email = email
-        self.token: Optional[str] = None
-        self.token_expires: Optional[float] = None
-        # cached last-known user_info (populated at login or initial fetch)
-        self.user_info: Dict[str, Any] = {}
+        self.token: str | None = None
+        self.token_expires: float | None = None
+        self.user_info: dict[str, Any] = {}
+        self._last_measurements_meta: dict[str, dict[str, Any]] = {}
 
-        # measurements meta stored for incremental fetches during runtime:
-        # {"last_updated_at": int, "last_measurement_id": str}
-        self._last_measurements_meta: Dict[str, Any] = {}
-
-    def _build_url(self, path: str, extra_params: Optional[Dict[str, str]] = None) -> str:
+    def _build_url(self, path: str, extra_params: dict[str, str] | None = None) -> str:
+        """Build URL with query parameters."""
         params = copy.deepcopy(DEFAULT_QUERY_PARAMS)
         if extra_params:
             params.update({k: str(v) for k, v in extra_params.items()})
         query = urllib.parse.urlencode(params, safe="/")
         return f"{API_BASE}{path}?{query}"
 
-    async def async_login(self, password: str) -> Dict[str, Any]:
-        encrypted_pw = await self.hass.async_add_executor_job(self._encrypt_password, password)
+    async def async_login(self, password: str) -> dict[str, Any]:
+        """Authenticate with Feelfit API."""
+        encrypted_pw = await self.hass.async_add_executor_job(
+            self._encrypt_password, password
+        )
         payload = {"email": self.email, "password": encrypted_pw}
 
         url = self._build_url(PATH_LOGIN)
         timeout = ClientTimeout(total=15)
 
         try:
-            async with self._session.post(url, headers=LOGIN_HEADERS, json=payload, timeout=timeout) as resp:
+            async with self._session.post(
+                url, headers=LOGIN_HEADERS, json=payload, timeout=timeout
+            ) as resp:
                 text = await resp.text()
                 if resp.status != 200:
                     _LOGGER.error("Login HTTP error %s: %s", resp.status, text)
                     raise FeelfitApiError(f"HTTP {resp.status}: {text}")
                 result = await resp.json(content_type=None)
+        except FeelfitApiError:
+            raise
         except Exception as exc:
             _LOGGER.exception("Error while calling Feelfit login endpoint")
             raise FeelfitApiError(str(exc)) from exc
@@ -92,27 +96,37 @@ class FeelfitApi:
         return data
 
     def _encrypt_password(self, password: str) -> str:
+        """Encrypt password with RSA public key."""
         rsa_key = RSA.import_key(PUBLIC_KEY)
         cipher = PKCS1_v1_5.new(rsa_key)
         encrypted_bytes = cipher.encrypt(password.encode("utf-8"))
         return base64.b64encode(encrypted_bytes).decode("utf-8")
 
-    def auth_header(self) -> Dict[str, str]:
+    def auth_header(self) -> dict[str, str]:
+        """Return authorization header."""
         if not self.token:
             return {}
         return {"Authorization": f"Bearer {self.token}"}
 
-    async def _get(self, path: str, extra_params: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    async def _get(
+        self, path: str, extra_params: dict[str, str] | None = None
+    ) -> dict[str, Any]:
+        """Perform GET request to API."""
         url = self._build_url(path, extra_params)
         headers = {**COMMON_HEADERS, **self.auth_header()}
         timeout = ClientTimeout(total=15)
+
         try:
-            async with self._session.get(url, headers=headers, timeout=timeout) as resp:
+            async with self._session.get(
+                url, headers=headers, timeout=timeout
+            ) as resp:
                 text = await resp.text()
                 if resp.status != 200:
                     _LOGGER.error("GET %s returned %s: %s", url, resp.status, text)
                     raise FeelfitApiError(f"HTTP {resp.status}: {text}")
                 result = await resp.json(content_type=None)
+        except FeelfitApiError:
+            raise
         except Exception as exc:
             _LOGGER.exception("Error while GET %s", url)
             raise FeelfitApiError(str(exc)) from exc
@@ -121,99 +135,368 @@ class FeelfitApi:
             return result.get("data") or {}
         return result
 
-    async def async_get_primary_user(self) -> Dict[str, Any]:
-        """Get primary user profile (contains time_stamp used by the app)."""
+    async def async_get_primary_user(self) -> dict[str, Any]:
+        """Get primary user profile."""
         if not self.token:
             raise FeelfitApiError("Not authenticated")
         return await self._get(PATH_GET_PRIMARY_USER)
 
-    async def async_get_user_settings(self) -> Dict[str, Any]:
+    async def async_get_user_settings(self) -> dict[str, Any]:
+        """Get user settings."""
         if not self.token:
             raise FeelfitApiError("Not authenticated")
         return await self._get(PATH_USER_SETTINGS)
 
-    async def async_list_goals(self, user_id: str) -> Dict[str, Any]:
+    async def async_list_goals(self, user_id: str) -> dict[str, Any]:
+        """List user goals."""
         if not self.token:
             raise FeelfitApiError("Not authenticated")
         return await self._get(PATH_GOALS, {"user_id": user_id})
 
-    async def async_list_device_binds(self) -> Dict[str, Any]:
+    async def async_list_device_binds(self) -> dict[str, Any]:
+        """List bound devices."""
         if not self.token:
             raise FeelfitApiError("Not authenticated")
         return await self._get(PATH_DEVICE_BINDS)
 
-    async def async_get_last_measurements(self, user_id: str, last_updated_at: int = 0, last_measurement_id: int = 0) -> Dict[str, Any]:
-        """Call measurements endpoint."""
+    async def async_list_all_profiles(self) -> list[dict[str, Any]]:
+        """List all user profiles (primary + sub users)."""
         if not self.token:
             raise FeelfitApiError("Not authenticated")
-        extra = {"user_id": user_id, "last_updated_at": str(last_updated_at), "last_measurement_id": str(last_measurement_id)}
+
+        profiles: list[dict[str, Any]] = []
+
+        try:
+            primary_data = await self._get(PATH_GET_PRIMARY_USER)
+            primary_user = primary_data.get("user_info")
+
+            if primary_user:
+                primary_user["is_primary"] = True
+
+                if not primary_user.get("account_name"):
+                    primary_user["account_name"] = (
+                        primary_user.get("nickname") or
+                        primary_user.get("name") or
+                        primary_user.get("username") or
+                        primary_user.get("email", "").split("@")[0] if primary_user.get("email") else None or
+                        "Profilo Primario"
+                    )
+                _LOGGER.debug("Primary profile: user_id=%s, account_name=%s",
+                             primary_user.get("user_id"),
+                             primary_user.get("account_name"))
+                profiles.append(primary_user)
+        except Exception as exc:
+            _LOGGER.error("Failed to fetch primary user: %s", exc)
+
+        try:
+
+            sub_users_data = await self._get("/sub_users/list_sub_user")
+
+            _LOGGER.debug("Sub users response: %s", sub_users_data)
+
+            sub_users = []
+            if isinstance(sub_users_data, dict):
+                sub_users = (
+                    sub_users_data.get("sub_users") or
+                    sub_users_data.get("data") or
+                    sub_users_data.get("users") or
+                    []
+                )
+            elif isinstance(sub_users_data, list):
+                sub_users = sub_users_data
+
+            _LOGGER.debug("Found %d sub users", len(sub_users))
+
+            for idx, user in enumerate(sub_users):
+                user["is_primary"] = False
+
+                if not user.get("account_name"):
+                    user["account_name"] = (
+                        user.get("nickname") or
+                        user.get("name") or
+                        user.get("username") or
+                        user.get("email", "").split("@")[0] if user.get("email") else None or
+                        f"Profilo {idx + 2}"
+                    )
+                _LOGGER.debug("Sub user %d: user_id=%s, account_name=%s",
+                             idx + 1,
+                             user.get("user_id"),
+                             user.get("account_name"))
+                profiles.append(user)
+
+        except Exception as exc:
+            _LOGGER.warning("Failed to fetch sub users (might not exist): %s", exc)
+
+        _LOGGER.info("Found %d profiles total: %s",
+                     len(profiles),
+                     [f"{p.get('account_name')} (id={p.get('user_id')})" for p in profiles])
+        return profiles
+
+    async def async_get_last_measurements(
+        self, user_id: str, last_updated_at: int = 0, last_measurement_id: int = 0
+    ) -> dict[str, Any]:
+        """Get measurements from API."""
+        if not self.token:
+            raise FeelfitApiError("Not authenticated")
+        extra = {
+            "user_id": user_id,
+            "last_updated_at": str(last_updated_at),
+            "last_measurement_id": str(last_measurement_id),
+        }
         return await self._get(PATH_MEASUREMENTS, extra)
 
-    async def async_fetch_all(self, user_id: str) -> Dict[str, Any]:
-        """Fetch aggregated data and perform robust incremental measurements fetch."""
+    async def async_fetch_all(
+        self, user_id: str, selected_profiles: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Fetch all data from API for selected profiles.
+
+        Args:
+            user_id: Primary user ID (for backward compatibility)
+            selected_profiles: List of user_ids to fetch. If None, fetch all profiles.
+        """
         if not self.token:
             raise FeelfitApiError("Not authenticated")
 
-        # Step A: get primary user first (to know latest user time_stamp used by the app)
-        primary_data: Dict[str, Any] = {}
+        all_profiles: list[dict[str, Any]] = []
+        primary_data: dict[str, Any] = {}
+
+        try:
+            all_profiles = await self.async_list_all_profiles()
+            primary_data = await self.async_get_primary_user()
+            if isinstance(primary_data, dict) and "user_info" in primary_data:
+                self.user_info = primary_data.get("user_info") or self.user_info
+        except Exception as exc:
+            _LOGGER.debug("Could not fetch profiles: %s", exc)
+
+        if selected_profiles:
+            profiles_to_fetch = [
+                p for p in all_profiles
+                if str(p.get("user_id")) in selected_profiles
+            ]
+            _LOGGER.debug(
+                "Fetching %d of %d profiles based on selection",
+                len(profiles_to_fetch),
+                len(all_profiles)
+            )
+        else:
+            profiles_to_fetch = all_profiles
+            _LOGGER.debug("Fetching all %d profiles", len(profiles_to_fetch))
+
+        all_profiles_data: list[dict[str, Any]] = []
+
+        for profile in profiles_to_fetch:
+            profile_user_id = str(profile.get("user_id"))
+            _LOGGER.debug("Fetching data for profile: %s", profile.get("account_name"))
+
+            last_known_meta = self._last_measurements_meta.get(profile_user_id, {})
+            last_known_updated_at = int(last_known_meta.get("last_updated_at") or 0)
+            primary_ts = 0
+
+            try:
+                if profile.get("time_stamp"):
+                    primary_ts = int(profile.get("time_stamp"))
+            except (ValueError, TypeError):
+                primary_ts = 0
+
+            if last_known_updated_at > 0:
+                request_last_updated_at = last_known_updated_at
+            elif primary_ts > 0:
+                request_last_updated_at = primary_ts
+            else:
+                request_last_updated_at = 0
+
+            last_measurement_id = int(last_known_meta.get("last_measurement_id", 0) or 0)
+
+            _LOGGER.debug(
+                "Profile %s measurements fetch: last_known=%s primary_ts=%s request=%s measurement_id=%s",
+                profile.get("account_name"),
+                last_known_updated_at,
+                primary_ts,
+                request_last_updated_at,
+                last_measurement_id,
+            )
+
+            tasks = [
+                self.async_get_user_settings(),
+                self.async_list_goals(profile_user_id),
+                self.async_get_last_measurements(
+                    profile_user_id,
+                    last_updated_at=request_last_updated_at,
+                    last_measurement_id=last_measurement_id,
+                ),
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            user_settings: dict[str, Any] = {}
+            goals: dict[str, Any] = {}
+            measurements_data: dict[str, Any] = {}
+
+            for idx, res in enumerate(results):
+                if isinstance(res, Exception):
+                    _LOGGER.error("Error fetching index %s for profile %s: %s",
+                                idx, profile.get("account_name"), res)
+                    continue
+                if idx == 0:
+                    user_settings = res or {}
+                elif idx == 1:
+                    goals = res or {}
+                elif idx == 2:
+                    measurements_data = res or {}
+
+            measurements_list = measurements_data.get("measurements") or []
+            if not measurements_list and primary_ts and primary_ts != last_known_updated_at:
+                _LOGGER.debug(
+                    "Profile %s measurements empty, retrying with last_updated_at=0 as fallback",
+                    profile.get("account_name")
+                )
+                try:
+                    fallback = await self.async_get_last_measurements(
+                        profile_user_id, last_updated_at=0, last_measurement_id=0
+                    )
+                    measurements_data = fallback or {}
+                    measurements_list = measurements_data.get("measurements") or []
+                except Exception as exc:
+                    _LOGGER.debug("Fallback measurements fetch failed for profile %s: %s",
+                                profile.get("account_name"), exc)
+
+            try:
+                returned_last_updated_at = int(measurements_data.get("last_updated_at") or 0)
+                returned_last_measurement_id = measurements_data.get("last_measurement_id") or 0
+
+                if profile_user_id not in self._last_measurements_meta:
+                    self._last_measurements_meta[profile_user_id] = {}
+
+                if returned_last_updated_at:
+                    self._last_measurements_meta[profile_user_id]["last_updated_at"] = returned_last_updated_at
+                if returned_last_measurement_id:
+                    self._last_measurements_meta[profile_user_id]["last_measurement_id"] = returned_last_measurement_id
+
+                _LOGGER.debug("Updated measurements meta for profile %s: %s",
+                            profile.get("account_name"),
+                            self._last_measurements_meta[profile_user_id])
+            except (ValueError, TypeError):
+                _LOGGER.debug(
+                    "Could not update measurements meta for profile %s from response: %s",
+                    profile.get("account_name"),
+                    measurements_data
+                )
+
+            last_measurement = measurements_list[0] if measurements_list else None
+
+            profile_data = {
+                "user_info": profile,
+                "user_settings": user_settings,
+                "goals": goals,
+                "measurements": {
+                    "last_measurement": last_measurement,
+                    "measurements": measurements_list,
+                    "last_updated_at": measurements_data.get("last_updated_at"),
+                },
+            }
+            all_profiles_data.append(profile_data)
+
+        device_binds_data: dict[str, Any] = {}
+        try:
+            device_binds_data = await self.async_list_device_binds()
+        except Exception as exc:
+            _LOGGER.error("Error fetching device binds: %s", exc)
+
+        device_binds = device_binds_data.get("device_binds") or []
+        device_models = device_binds_data.get("device_models") or []
+
+        model_by_scale_and_internal: dict[tuple[Any, Any], dict[str, Any]] = {}
+        model_by_scale: dict[str, dict[str, Any]] = {}
+
+        for m in device_models:
+            key = (m.get("scale_name"), m.get("internal_model"))
+            if key not in model_by_scale_and_internal:
+                model_by_scale_and_internal[key] = m
+            scale = m.get("scale_name")
+            if scale and scale not in model_by_scale:
+                model_by_scale[scale] = m
+
+        enriched_devices: list[dict[str, Any]] = []
+        for d in device_binds:
+            match = model_by_scale_and_internal.get(
+                (d.get("scale_name"), d.get("internal_model"))
+            )
+            if not match:
+                match = model_by_scale.get(d.get("scale_name", ""))
+            merged = dict(d)
+            if match:
+                merged["model_info"] = match
+                brand = match.get("brand_info") or {}
+                if brand.get("brand_name"):
+                    merged["brand_name"] = brand.get("brand_name")
+            enriched_devices.append(merged)
+
+        return {
+            "profiles": all_profiles_data,
+            "all_profiles": all_profiles,
+            "device_binds": {
+                "device_binds": enriched_devices,
+                "device_models": device_models,
+            },
+            "primary_user": primary_data or {},
+        }
+        """Fetch all data from API."""
+        if not self.token:
+            raise FeelfitApiError("Not authenticated")
+
+        primary_data: dict[str, Any] = {}
         try:
             primary_data = await self.async_get_primary_user()
             if isinstance(primary_data, dict) and "user_info" in primary_data:
-                # update cached user_info
                 self.user_info = primary_data.get("user_info") or self.user_info
         except Exception as exc:
-            # log but continue — other endpoints may still work
             _LOGGER.debug("Could not fetch primary user: %s", exc)
 
-        # compute last_updated_at to use for measurements fetch
         last_known_meta = self._last_measurements_meta or {}
         last_known_updated_at = int(last_known_meta.get("last_updated_at") or 0)
         primary_ts = 0
+
         try:
             pu = primary_data.get("user_info") if isinstance(primary_data, dict) else None
             if pu and pu.get("time_stamp"):
                 primary_ts = int(pu.get("time_stamp"))
             elif self.user_info and self.user_info.get("time_stamp"):
                 primary_ts = int(self.user_info.get("time_stamp"))
-        except Exception:
+        except (ValueError, TypeError):
             primary_ts = 0
 
-        # Decide base_last_updated_at for the request:
-        # - if we already have a measurements last_updated_at, use it (incremental)
-        # - otherwise, fall back to primary_ts if present, else 0
         if last_known_updated_at > 0:
             request_last_updated_at = last_known_updated_at
         elif primary_ts > 0:
-            # if we don't have any previous measurements meta, use primary_ts as baseline
             request_last_updated_at = primary_ts
         else:
             request_last_updated_at = 0
 
-        # For measurement id we will use stored last_measurement_id (if any)
-        last_measurement_id = last_known_meta.get("last_measurement_id", 0) or 0
+        last_measurement_id = int(last_known_meta.get("last_measurement_id", 0) or 0)
 
         _LOGGER.debug(
-            "Measurements fetch decision: last_known_updated_at=%s primary_ts=%s requesting last_updated_at=%s last_measurement_id=%s",
+            "Measurements fetch: last_known=%s primary_ts=%s request=%s measurement_id=%s",
             last_known_updated_at,
             primary_ts,
             request_last_updated_at,
             last_measurement_id,
         )
 
-        # Now trigger other endpoints concurrently including measurements
-        # Use the chosen request_last_updated_at for measurements call
         tasks = [
             self.async_get_user_settings(),
             self.async_list_goals(user_id),
             self.async_list_device_binds(),
-            self.async_get_last_measurements(user_id, last_updated_at=request_last_updated_at, last_measurement_id=last_measurement_id),
+            self.async_get_last_measurements(
+                user_id,
+                last_updated_at=request_last_updated_at,
+                last_measurement_id=last_measurement_id,
+            ),
         ]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        user_settings = {}
-        goals = {}
-        device_binds_data = {}
-        measurements_data = {}
+        user_settings: dict[str, Any] = {}
+        goals: dict[str, Any] = {}
+        device_binds_data: dict[str, Any] = {}
+        measurements_data: dict[str, Any] = {}
 
         for idx, res in enumerate(results):
             if isinstance(res, Exception):
@@ -228,21 +511,20 @@ class FeelfitApi:
             elif idx == 3:
                 measurements_data = res or {}
 
-        # If measurements returned empty but primary_ts increased compared to last_known_updated_at,
-        # try a safe fallback: request a full fetch (last_updated_at=0) to avoid missing a measurement.
         measurements_list = measurements_data.get("measurements") or []
-        if not measurements_list:
-            # If primary_ts suggests there might be newer data and we didn't have previous metadata, try fallback
-            if primary_ts and primary_ts != last_known_updated_at:
-                _LOGGER.debug("Measurements empty. primary_ts=%s != last_known_updated_at=%s -> retrying measurements with last_updated_at=0 as fallback", primary_ts, last_known_updated_at)
-                try:
-                    fallback = await self.async_get_last_measurements(user_id, last_updated_at=0, last_measurement_id=0)
-                    measurements_data = fallback or {}
-                    measurements_list = measurements_data.get("measurements") or []
-                except Exception as exc:
-                    _LOGGER.debug("Fallback measurements fetch failed: %s", exc)
+        if not measurements_list and primary_ts and primary_ts != last_known_updated_at:
+            _LOGGER.debug(
+                "Measurements empty, retrying with last_updated_at=0 as fallback"
+            )
+            try:
+                fallback = await self.async_get_last_measurements(
+                    user_id, last_updated_at=0, last_measurement_id=0
+                )
+                measurements_data = fallback or {}
+                measurements_list = measurements_data.get("measurements") or []
+            except Exception as exc:
+                _LOGGER.debug("Fallback measurements fetch failed: %s", exc)
 
-        # After potential fallback, update stored measurements meta
         try:
             returned_last_updated_at = int(measurements_data.get("last_updated_at") or 0)
             returned_last_measurement_id = measurements_data.get("last_measurement_id") or 0
@@ -250,17 +532,18 @@ class FeelfitApi:
                 self._last_measurements_meta["last_updated_at"] = returned_last_updated_at
             if returned_last_measurement_id:
                 self._last_measurements_meta["last_measurement_id"] = returned_last_measurement_id
-            _LOGGER.debug("Updated internal measurements meta: %s", self._last_measurements_meta)
-        except Exception:
-            # be defensive: don't break on unexpected types
-            _LOGGER.debug("Could not update last measurements meta from response: %s", measurements_data)
+            _LOGGER.debug("Updated measurements meta: %s", self._last_measurements_meta)
+        except (ValueError, TypeError):
+            _LOGGER.debug(
+                "Could not update measurements meta from response: %s", measurements_data
+            )
 
-        # Enrich device_binds with device_models
         device_binds = device_binds_data.get("device_binds") or []
         device_models = device_binds_data.get("device_models") or []
 
-        model_by_scale_and_internal = {}
-        model_by_scale = {}
+        model_by_scale_and_internal: dict[tuple[Any, Any], dict[str, Any]] = {}
+        model_by_scale: dict[str, dict[str, Any]] = {}
+
         for m in device_models:
             key = (m.get("scale_name"), m.get("internal_model"))
             if key not in model_by_scale_and_internal:
@@ -269,32 +552,35 @@ class FeelfitApi:
             if scale and scale not in model_by_scale:
                 model_by_scale[scale] = m
 
-        enriched_devices = []
+        enriched_devices: list[dict[str, Any]] = []
         for d in device_binds:
-            match = model_by_scale_and_internal.get((d.get("scale_name"), d.get("internal_model")))
+            match = model_by_scale_and_internal.get(
+                (d.get("scale_name"), d.get("internal_model"))
+            )
             if not match:
-                match = model_by_scale.get(d.get("scale_name"))
+                match = model_by_scale.get(d.get("scale_name", ""))
+            merged = dict(d)
             if match:
-                merged = dict(d)
                 merged["model_info"] = match
                 brand = match.get("brand_info") or {}
                 if brand.get("brand_name"):
                     merged["brand_name"] = brand.get("brand_name")
-            else:
-                merged = dict(d)
             enriched_devices.append(merged)
 
-        # choose last_measurement if any
-        last_measurement = None
-        if measurements_list:
-            last_measurement = measurements_list[0]
+        last_measurement = measurements_list[0] if measurements_list else None
 
-        payload = {
+        return {
             "user_info": self.user_info,
             "user_settings": user_settings,
             "goals": goals,
-            "device_binds": {"device_binds": enriched_devices, "device_models": device_models},
-            "measurements": {"last_measurement": last_measurement, "measurements": measurements_list, "last_updated_at": measurements_data.get("last_updated_at")},
+            "device_binds": {
+                "device_binds": enriched_devices,
+                "device_models": device_models,
+            },
+            "measurements": {
+                "last_measurement": last_measurement,
+                "measurements": measurements_list,
+                "last_updated_at": measurements_data.get("last_updated_at"),
+            },
             "primary_user": primary_data or {},
         }
-        return payload

--- a/custom_components/feelfit/config_flow.py
+++ b/custom_components/feelfit/config_flow.py
@@ -2,64 +2,293 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any
 
-from aiohttp import ClientSession
 import voluptuous as vol
+from aiohttp import ClientSession
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import selector
 
 from .api import FeelfitApi, FeelfitApiError
-from .const import DOMAIN, LOGGER
+from .const import CONF_PROFILES_LIST, CONF_SELECTED_PROFILES, DOMAIN, LOGGER
 
 _LOGGER = logging.getLogger(LOGGER)
 
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("email"): str,
+        vol.Required("password"): str,
+    }
+)
+
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+    session: ClientSession = async_get_clientsession(hass)
+    client = FeelfitApi(hass, session, data["email"].strip())
+
+    login_data = await client.async_login(data["password"])
+    return login_data
 
 class FeelfitConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Feelfit."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self) -> None:
+        """Initialize the config flow."""
         self._email: str | None = None
+        self._token: str | None = None
+        self._token_expires: str | None = None
+        self._user_info: dict[str, Any] = {}
+        self._all_profiles: list[dict[str, Any]] = []
+        self._label_to_user_id: dict[str, str] = {}
 
-    async def async_step_user(self, user_input: Dict[str, Any] | None = None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the initial step which asks for email and password."""
-        errors = {}
-        if user_input is not None:
-            email = user_input["email"].strip()
-            password = user_input["password"]
+        errors: dict[str, str] = {}
 
-            session: ClientSession = async_get_clientsession(self.hass)
-            client = FeelfitApi(self.hass, session, email)
+        if user_input is not None:
             try:
-                data = await client.async_login(password)
+                login_data = await validate_input(self.hass, user_input)
             except FeelfitApiError as exc:
                 _LOGGER.debug("Login attempt failed: %s", exc)
-                errors["base"] = "auth"
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
             else:
-                user_info = data.get("user_info", {})
-                token = data.get("token_info", {}).get("token")
-                remaining_time = data.get("token_info", {}).get("remaining_time")
-                unique_id = user_info.get("user_id") or email
-                await self.async_set_unique_id(str(unique_id))
-                self._abort_if_unique_id_configured()
-                # Store login token + user_info in config entry data for now
-                entry_data = {
-                    "email": email,
-                    "token": token,
-                    "token_expires": None if not remaining_time else str(int(remaining_time)),
-                    "user_info": user_info,
-                }
-                return self.async_create_entry(title=user_info.get("account_name") or email, data=entry_data)
 
-        data_schema = vol.Schema(
-            {
-                vol.Required("email"): str,
-                vol.Required("password"): str,
-            }
+                self._user_info = login_data.get("user_info", {})
+                token_info = login_data.get("token_info", {})
+                self._token = token_info.get("token")
+                remaining_time = token_info.get("remaining_time")
+                self._token_expires = str(int(remaining_time)) if remaining_time else None
+                self._email = user_input["email"].strip()
+
+                session = async_get_clientsession(self.hass)
+                client = FeelfitApi(self.hass, session, self._email)
+                client.token = self._token
+
+                try:
+                    self._all_profiles = await client.async_list_all_profiles()
+                    _LOGGER.debug("Found %d profiles", len(self._all_profiles))
+                    for idx, p in enumerate(self._all_profiles):
+                        _LOGGER.debug(
+                            "Profile %d: user_id=%s, account_name=%s, nickname=%s, email=%s, is_primary=%s",
+                            idx + 1,
+                            p.get("user_id"),
+                            p.get("account_name"),
+                            p.get("nickname"),
+                            p.get("email"),
+                            p.get("is_primary")
+                        )
+                except Exception as exc:
+                    _LOGGER.error("Failed to fetch profiles: %s", exc)
+                    self._all_profiles = [self._user_info]
+
+                return await self.async_step_select_profiles()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
         )
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_select_profiles(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle profile selection step."""
+        if user_input is not None:
+
+            selected = []
+            for label, is_selected in user_input.items():
+                if is_selected and label != CONF_SELECTED_PROFILES:
+
+                    user_id = self._label_to_user_id.get(label, label)
+                    selected.append(user_id)
+
+            if not selected:
+
+                primary = next(
+                    (p for p in self._all_profiles if p.get("is_primary", False)),
+                    self._all_profiles[0] if self._all_profiles else self._user_info
+                )
+                selected = [str(primary.get("user_id"))]
+
+            unique_id = self._user_info.get("user_id") or self._email
+            await self.async_set_unique_id(str(unique_id))
+            self._abort_if_unique_id_configured()
+
+            entry_data = {
+                "email": self._email,
+                "token": self._token,
+                "token_expires": self._token_expires,
+                "user_info": self._user_info,
+                CONF_SELECTED_PROFILES: selected,
+                CONF_PROFILES_LIST: [
+                    {
+                        "user_id": str(p.get("user_id")),
+                        "account_name": p.get("account_name"),
+                        "is_primary": p.get("is_primary", False),
+                    }
+                    for p in self._all_profiles
+                ],
+            }
+
+            title = self._user_info.get("account_name") or self._email
+            if len(selected) > 1:
+                title = f"{title} (+{len(selected)-1} profili)"
+
+            return self.async_create_entry(title=title, data=entry_data)
+
+        profiles_schema = {}
+        for profile in self._all_profiles:
+            user_id = str(profile.get("user_id"))
+            account_name = profile.get("account_name", "Profilo sconosciuto")
+            is_primary = profile.get("is_primary", False)
+
+            label = f"{account_name}"
+            if is_primary:
+                label += " (Primario)"
+
+            email = profile.get("email")
+            if email:
+                label += f" - {email}"
+
+            _LOGGER.debug("Profile in UI: user_id=%s, label=%s", user_id, label)
+
+            profiles_schema[vol.Optional(label, default=is_primary, description={"suggested_value": is_primary})] = selector.BooleanSelector()
+
+        self._label_to_user_id = {}
+        for p in self._all_profiles:
+            account_name = p.get('account_name', 'Profilo sconosciuto')
+            is_primary_label = ' (Primario)' if p.get('is_primary') else ''
+            email_part = f" - {p.get('email')}" if p.get('email') else ''
+            label_key = f"{account_name}{is_primary_label}{email_part}"
+            self._label_to_user_id[label_key] = str(p.get("user_id"))
+
+        return self.async_show_form(
+            step_id="select_profiles",
+            data_schema=vol.Schema(profiles_schema),
+            description_placeholders={
+                "num_profiles": str(len(self._all_profiles))
+            },
+        )
+
+    @staticmethod
+    @config_entries.callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Get the options flow for this handler."""
+        return FeelfitOptionsFlowHandler(config_entry)
+
+class FeelfitOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Feelfit options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+
+        self._all_profiles: list[dict[str, Any]] = []
+        self._label_to_user_id: dict[str, str] = {}
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        return await self.async_step_profiles()
+
+    async def async_step_profiles(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle profile selection in options."""
+
+        email = self.config_entry.data.get("email")
+        token = self.config_entry.data.get("token")
+        user_info = self.config_entry.data.get("user_info") or {}
+
+        if not email or not token:
+            return self.async_abort(reason="missing_credentials")
+
+        try:
+            session: ClientSession = async_get_clientsession(self.hass)
+            api = FeelfitApi(self.hass, session, email)
+            api.token = token
+            api.user_info = user_info
+
+            self._all_profiles = await api.async_list_all_profiles()
+
+        except Exception as exc:
+            _LOGGER.error("Failed to fetch profiles in options: %s", exc, exc_info=True)
+            return self.async_abort(reason="fetch_failed")
+
+        if user_input is not None:
+
+            selected = []
+            for label, is_selected in user_input.items():
+                if is_selected:
+                    user_id = self._label_to_user_id.get(label, label)
+                    selected.append(user_id)
+
+            if not selected:
+
+                primary = next(
+                    (p for p in self._all_profiles if p.get("is_primary", False)),
+                    self._all_profiles[0] if self._all_profiles else None
+                )
+                if primary:
+                    selected = [str(primary.get("user_id"))]
+
+            return self.async_create_entry(
+                title="",
+                data={CONF_SELECTED_PROFILES: selected}
+            )
+
+        profiles_schema = {}
+
+        current_selection = self.config_entry.options.get(
+            CONF_SELECTED_PROFILES,
+            self.config_entry.data.get(CONF_SELECTED_PROFILES, [])
+        )
+
+        for profile in self._all_profiles:
+            user_id = str(profile.get("user_id"))
+            account_name = profile.get("account_name", "Profilo sconosciuto")
+            is_primary = profile.get("is_primary", False)
+
+            label = f"{account_name}"
+            if is_primary:
+                label += " (Primario)"
+
+            email_addr = profile.get("email")
+            if email_addr:
+                label += f" - {email_addr}"
+
+            is_selected = user_id in current_selection
+
+            _LOGGER.debug("Options profile: user_id=%s, label=%s, selected=%s", user_id, label, is_selected)
+
+            profiles_schema[vol.Optional(label, default=is_selected)] = selector.BooleanSelector()
+
+        for p in self._all_profiles:
+            account_name = p.get('account_name', 'Profilo sconosciuto')
+            is_primary_label = ' (Primario)' if p.get('is_primary') else ''
+            email_part = f" - {p.get('email')}" if p.get('email') else ''
+            label_key = f"{account_name}{is_primary_label}{email_part}"
+            self._label_to_user_id[label_key] = str(p.get("user_id"))
+
+        return self.async_show_form(
+            step_id="profiles",
+            data_schema=vol.Schema(profiles_schema),
+            description_placeholders={
+                "num_profiles": str(len(self._all_profiles))
+            },
+        )

--- a/custom_components/feelfit/const.py
+++ b/custom_components/feelfit/const.py
@@ -1,15 +1,19 @@
 """Constants for the Feelfit integration (centralized)."""
 
+from datetime import timedelta
 from typing import Dict
 
 DOMAIN = "feelfit"
 PLATFORMS = ["sensor"]
 LOGGER = "custom_components.feelfit"
 
-# Base API
+SCAN_INTERVAL = timedelta(seconds=120)
+
+CONF_SELECTED_PROFILES = "selected_profiles"
+CONF_PROFILES_LIST = "profiles_list"
+
 API_BASE = "https://feelfit.qnclouds.com/api/v4"
 
-# Default query params used by all endpoints (centralized)
 DEFAULT_QUERY_PARAMS: Dict[str, str] = {
     "app_revision": "4.16.0",
     "html_version": "14.16.0",
@@ -22,15 +26,13 @@ DEFAULT_QUERY_PARAMS: Dict[str, str] = {
     "platform": "android",
 }
 
-# Endpoint paths (only paths, not full URLs)
 PATH_LOGIN = "/users/sign_in"
 PATH_USER_SETTINGS = "/user_settings/show_common_setting"
 PATH_GOALS = "/goals/list_goal"
 PATH_DEVICE_BINDS = "/device_binds/list_device_bind"
 PATH_MEASUREMENTS = "/measurements/list_measurement"
-PATH_GET_PRIMARY_USER = "/users/get_primary_user"  
+PATH_GET_PRIMARY_USER = "/users/get_primary_user"
 
-# Public key (for password encryption)
 PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+25I2upukpfQ7rIaaTZtVE744
 u2zV+HaagrUhDOTq8fMVf9yFQvEZh2/HKxFudUxP0dXUa8F6X4XmWumHdQnum3zm
@@ -38,16 +40,14 @@ Jr04fz2b2WCcN0ta/rbF2nYAnMVAk2OJVZAMudOiMWhcxV1nNJiKgTNNr13de0EQ
 IiOL2CUBzu+HmIfUbQIDAQAB
 -----END PUBLIC KEY-----"""
 
-# Common headers (Authorization merged per request as needed)
-COMMON_HEADERS = {
+COMMON_HEADERS: Dict[str, str] = {
     "Accept-Encoding": "gzip",
     "Connection": "Keep-Alive",
     "Host": "feelfit.qnclouds.com",
     "User-Agent": "okhttp/4.9.1",
 }
 
-# Login-specific headers (content-type + placeholder Authorization as original)
-LOGIN_HEADERS = {
+LOGIN_HEADERS: Dict[str, str] = {
     **COMMON_HEADERS,
     "Authorization": "Bearer",
     "Content-Type": "application/json;charset=UTF-8",

--- a/custom_components/feelfit/sensor.py
+++ b/custom_components/feelfit/sensor.py
@@ -1,35 +1,36 @@
 """Sensor platform for Feelfit — coordinator-backed entities (auto-refresh)."""
-
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
 from typing import Any
-from datetime import timedelta, datetime
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
     DataUpdateCoordinator,
     UpdateFailed,
-    CoordinatorEntity,
 )
 
-from .const import DOMAIN, LOGGER
+from .const import CONF_SELECTED_PROFILES, DOMAIN, LOGGER, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(LOGGER)
 
-# Units
 try:
     from homeassistant.const import UnitOfMass
     KG_UNIT = UnitOfMass.KILOGRAMS
-except Exception:
+except ImportError:
     KG_UNIT = "kg"
 
 PERCENT = "%"
 KCAL = "kcal"
 BPM = "bpm"
 
-
 def _map_date_format(fmt: str) -> str:
+    """Map Feelfit date format to Python strftime format."""
     if not fmt:
         return "%Y-%m-%d"
     mapping = {"dd": "%d", "MM": "%m", "yyyy": "%Y", "yy": "%y"}
@@ -38,10 +39,11 @@ def _map_date_format(fmt: str) -> str:
         out = out.replace(k, v)
     return out
 
-
 def _format_birthday(raw_birthday: Any, date_format: str | None) -> str | None:
+    """Format birthday from various input formats."""
     if not raw_birthday:
         return None
+
     try:
         if isinstance(raw_birthday, int):
             dt = datetime.fromtimestamp(raw_birthday)
@@ -52,184 +54,264 @@ def _format_birthday(raw_birthday: Any, date_format: str | None) -> str | None:
             dt = datetime.fromtimestamp(ts)
             fmt = _map_date_format(date_format or "")
             return dt.strftime(fmt)
-    except Exception:
+    except (ValueError, OSError):
         pass
+
     try:
-        dt = datetime.strptime(raw_birthday, "%Y-%m-%d")
+        dt = datetime.strptime(str(raw_birthday), "%Y-%m-%d")
         fmt = _map_date_format(date_format or "")
         return dt.strftime(fmt)
-    except Exception:
+    except ValueError:
         return str(raw_birthday)
 
-
-async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up sensors for Feelfit (coordinator, 60s poll)."""
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors for Feelfit - multi-profile support."""
     data = hass.data[DOMAIN][entry.entry_id]
     api = data["api"]
+    selected_profiles = data.get("selected_profiles") or []
     initial_user_info = data.get("user_info") or {}
     user_id = initial_user_info.get("user_id") or entry.unique_id or entry.entry_id
 
-    async def async_update_data():
-        """Coordinator update method — calls api.async_fetch_all which itself obtains primary_user first."""
+    async def async_update_data() -> dict[str, Any]:
+        """Coordinator update method."""
         try:
-            payload = await api.async_fetch_all(str(user_id))
-            _LOGGER.debug("Feelfit coordinator fetched payload keys: %s", list(payload.keys()))
+            payload = await api.async_fetch_all(
+                str(user_id),
+                selected_profiles=selected_profiles if selected_profiles else None
+            )
+            _LOGGER.debug("Feelfit coordinator fetched keys: %s", list(payload.keys()))
             return payload
         except Exception as err:
             _LOGGER.debug("Feelfit coordinator update failed: %s", err)
             raise UpdateFailed(f"Feelfit fetch failed: {err}") from err
 
-    coordinator = DataUpdateCoordinator(
+    coordinator: DataUpdateCoordinator[dict[str, Any]] = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="feelfit",
         update_method=async_update_data,
-        update_interval=timedelta(seconds=30),
+        update_interval=SCAN_INTERVAL,
     )
 
     await coordinator.async_refresh()
     data_fetched = coordinator.data or {}
-    user_info = data_fetched.get("user_info") or initial_user_info
-    user_settings = data_fetched.get("user_settings") or {}
-    goals_payload = data_fetched.get("goals") or {}
+
+    profiles = data_fetched.get("profiles") or []
     device_binds_payload = data_fetched.get("device_binds") or {}
-    measurements_payload = data_fetched.get("measurements") or {}
 
     entities: list[SensorEntity] = []
 
-    # Basic user_info sensors
-    if user_info:
-        entities.append(FeelfitUserSensor(coordinator, entry.entry_id, "account_name", "Account Name", None))
-        if user_info.get("weight") is not None:
-            entities.append(FeelfitUserSensor(coordinator, entry.entry_id, "weight", "Weight", KG_UNIT))
-        if user_info.get("height") is not None:
-            entities.append(FeelfitUserSensor(coordinator, entry.entry_id, "height", "Height", "cm"))
-        if "birthday" in user_info:
-            entities.append(FeelfitBirthdaySensor(coordinator, entry.entry_id, "birthday", "Birthday"))
-        if user_info.get("email"):
-            entities.append(FeelfitUserSensor(coordinator, entry.entry_id, "email", "Email", None))
+    for profile_data in profiles:
+        user_info = profile_data.get("user_info") or {}
+        profile_user_id = str(user_info.get("user_id", ""))
+        account_name = user_info.get("account_name") or "Unknown"
+        is_primary = user_info.get("is_primary", True)
 
-    # goals sensors
-    goals_list = goals_payload.get("goals") or []
-    for g in goals_list:
-        g_type = g.get("goal_type")
-        unique = f"goal_{g_type}"
-        label = f"Goal {g_type.title()}"
-        unit = None
-        if g_type == "weight":
-            unit = KG_UNIT
-        elif g_type == "bodyfat":
-            unit = PERCENT
-        elif g_type == "water":
-            unit = "ml"
-        entities.append(FeelfitGoalSensor(coordinator, entry.entry_id, unique, label, unit, g_type))
+        prefix = "" if is_primary else f"{account_name.lower().replace(' ', '_')}_"
+        display_prefix = "" if is_primary else f"{account_name} - "
 
-    # device binds sensors (enriched)
-    device_binds = (device_binds_payload or {}).get("device_binds") or []
-    for idx, d in enumerate(device_binds):
-        scale_name = d.get("scale_name") or d.get("internal_model") or f"device_{idx}"
-        unique = f"device_{idx}_{(d.get('mac') or idx)}"
-        label = f"Feelfit {scale_name}"
-        entities.append(FeelfitDeviceSensor(coordinator, entry.entry_id, unique, label, None, device_index=idx))
+        _LOGGER.debug(
+            "Creating sensors for profile: %s (user_id=%s, is_primary=%s, prefix=%s)",
+            account_name, profile_user_id, is_primary, prefix
+        )
 
-    # measurement sensors attached to person
-    last_measurement = measurements_payload.get("last_measurement")
-    if last_measurement:
-        measurement_keys = [
-            ("weight", "Weight", KG_UNIT),
-            ("bodyfat", "Bodyfat", PERCENT),
-            ("bmi", "BMI", None),
-            ("bmr", "BMR", KCAL),
-            ("bodyage", "Metabolic Age", "y"),
-            ("fat_free_weight", "Fat Free Weight", KG_UNIT),
-            ("muscle", "Muscle (%)", PERCENT),
-            ("protein", "Protein (%)", PERCENT),
-            ("sinew", "Sinew", PERCENT),
-            ("subfat", "Subcutaneous Fat (%)", PERCENT),
-            ("visfat", "Visceral Fat", None),
-            ("water", "Hydration (%)", PERCENT),
-            ("bone", "Bone Mass", KG_UNIT),
-            ("heart_rate", "Heart Rate", BPM),
-            ("score", "Score", None),
-            ("time_stamp", "Measurement Timestamp", None),
-            ("body_water_mass", "Body Water Mass", KG_UNIT),
-            ("protein_mass", "Protein Mass", KG_UNIT),
-            ("body_fat_mass", "Body Fat Mass", KG_UNIT),
-        ]
-
-        # unique preserve order
-        seen = set()
-        measurement_keys_unique = []
-        for k, l, u in measurement_keys:
-            if k not in seen:
-                seen.add(k)
-                measurement_keys_unique.append((k, l, u))
-
-        for key, label, unit in measurement_keys_unique:
-            unique = f"measurement_{key}"
-            name = f"Feelfit Last Measurement {label}"
+        if user_info:
             entities.append(
-                FeelfitMeasurementSensor(
-                    coordinator,
-                    entry.entry_id,
-                    unique,
-                    name,
-                    unit,
-                    measurement_key=key,
+                FeelfitUserSensor(
+                    coordinator, entry.entry_id, f"{prefix}account_name",
+                    f"{display_prefix}Account Name", None, profile_user_id
+                )
+            )
+            if user_info.get("weight") is not None:
+                entities.append(
+                    FeelfitUserSensor(
+                        coordinator, entry.entry_id, f"{prefix}weight",
+                        f"{display_prefix}Weight", KG_UNIT, profile_user_id
+                    )
+                )
+            if user_info.get("height") is not None:
+                entities.append(
+                    FeelfitUserSensor(
+                        coordinator, entry.entry_id, f"{prefix}height",
+                        f"{display_prefix}Height", "cm", profile_user_id
+                    )
+                )
+            if "birthday" in user_info:
+                entities.append(
+                    FeelfitBirthdaySensor(
+                        coordinator, entry.entry_id, f"{prefix}birthday",
+                        f"{display_prefix}Birthday", profile_user_id
+                    )
+                )
+            if user_info.get("email"):
+                entities.append(
+                    FeelfitUserSensor(
+                        coordinator, entry.entry_id, f"{prefix}email",
+                        f"{display_prefix}Email", None, profile_user_id
+                    )
+                )
+
+        goals_payload = profile_data.get("goals") or {}
+        goals_list = goals_payload.get("goals") or []
+        for g in goals_list:
+            g_type = g.get("goal_type")
+            if not g_type:
+                continue
+            unique = f"{prefix}goal_{g_type}"
+            label = f"{display_prefix}Goal {g_type.title()}"
+            unit: str | None = None
+            if g_type == "weight":
+                unit = KG_UNIT
+            elif g_type == "bodyfat":
+                unit = PERCENT
+            elif g_type == "water":
+                unit = "ml"
+            entities.append(
+                FeelfitGoalSensor(
+                    coordinator, entry.entry_id, unique, label, unit, g_type, profile_user_id
                 )
             )
 
+        measurements_payload = profile_data.get("measurements") or {}
+        last_measurement = measurements_payload.get("last_measurement")
+
+        if last_measurement:
+            measurement_keys: list[tuple[str, str, str | None]] = [
+                ("weight", "Weight", KG_UNIT),
+                ("bodyfat", "Bodyfat", PERCENT),
+                ("bmi", "BMI", None),
+                ("bmr", "BMR", KCAL),
+                ("bodyage", "Metabolic Age", "y"),
+                ("fat_free_weight", "Fat Free Weight", KG_UNIT),
+                ("muscle", "Muscle (%)", PERCENT),
+                ("protein", "Protein (%)", PERCENT),
+                ("sinew", "Sinew", PERCENT),
+                ("subfat", "Subcutaneous Fat (%)", PERCENT),
+                ("visfat", "Visceral Fat", None),
+                ("water", "Hydration (%)", PERCENT),
+                ("bone", "Bone Mass", KG_UNIT),
+                ("heart_rate", "Heart Rate", BPM),
+                ("score", "Score", None),
+                ("time_stamp", "Measurement Timestamp", None),
+                ("body_water_mass", "Body Water Mass", KG_UNIT),
+                ("protein_mass", "Protein Mass", KG_UNIT),
+                ("body_fat_mass", "Body Fat Mass", KG_UNIT),
+            ]
+
+            seen: set[str] = set()
+            for key, label, unit in measurement_keys:
+                if key in seen:
+                    continue
+                seen.add(key)
+                unique = f"{prefix}measurement_{key}"
+                name = f"{display_prefix}{label}"
+                entities.append(
+                    FeelfitMeasurementSensor(
+                        coordinator,
+                        entry.entry_id,
+                        unique,
+                        name,
+                        unit,
+                        measurement_key=key,
+                        profile_user_id=profile_user_id,
+                    )
+                )
+
+    device_binds = (device_binds_payload or {}).get("device_binds") or []
+    for idx, d in enumerate(device_binds):
+        scale_name = d.get("scale_name") or d.get("internal_model") or f"device_{idx}"
+        unique = f"device_{idx}_{d.get('mac') or idx}"
+        label = f"Feelfit {scale_name}"
+        entities.append(
+            FeelfitDeviceSensor(
+                coordinator, entry.entry_id, unique, label, None, device_index=idx
+            )
+        )
+
     async_add_entities(entities, True)
 
+class FeelfitUserSensor(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], SensorEntity):
+    """Sensor for user info attributes."""
 
-# ----------------------------
-# Entities (CoordinatorEntity + SensorEntity)
-# ----------------------------
-
-class FeelfitUserSensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str, attr_key: str, name: str, unit: str | None):
-        CoordinatorEntity.__init__(self, coordinator)
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
+        entry_id: str,
+        attr_key: str,
+        name: str,
+        unit: str | None,
+        profile_user_id: str | None = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
         self._entry_id = entry_id
         self._attr_key = attr_key
         self._name = name
         self._unit = unit
-        self._unique_id = f"{entry_id}_{attr_key}"
+        self._profile_user_id = profile_user_id
+
+        self._unique_id = f"{entry_id}_{attr_key}_{profile_user_id or 'primary'}"
         self._attr_translation_key = attr_key
         self._attr_has_entity_name = True
 
     @property
     def unique_id(self) -> str:
+        """Return unique ID."""
         return self._unique_id
 
-    # @property
-    # def name(self) -> str:
-        # return f"Feelfit {self._name}"
-
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str | None:
+        """Return unit of measurement."""
         return self._unit
 
     @property
-    def native_value(self):
-        user_info = (self.coordinator.data or {}).get("user_info") or {}
+    def native_value(self) -> Any:
+        """Return sensor value."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_info = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_info = profile_info
+                break
+
+        if not user_info and profiles:
+
+            user_info = profiles[0].get("user_info") or {}
+
+        if not user_info:
+            return None
+
         return user_info.get(self._attr_key)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra attributes."""
         return {"source": "feelfit", "attribute": self._attr_key}
 
     @property
-    def device_info(self):
-        # user_info = (self.coordinator.data or {}).get("user_info") or {}
-        # user_id = user_info.get("user_id")
-        # name = user_info.get("account_name") or f"Feelfit User {user_id or self._entry_id}"
-        # return {
-            # "identifiers": {(DOMAIN, user_id or self._entry_id)},
-            # "name": name,
-            # "manufacturer": "Feelfit",
-            # "model": "Feelfit Account",
-        # }
-        user_info = (self.coordinator.data or {}).get("user_info") or {}
+    def device_info(self) -> dict[str, Any]:
+        """Return device info."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_info = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_info = profile_info
+                break
+
+        if not user_info and profiles:
+            user_info = profiles[0].get("user_info") or {}
+
+        if not user_info:
+            user_info = {}
+
         user_id = user_info.get("user_id") or self._entry_id
         return {
             "identifiers": {(DOMAIN, f"user_{user_id}")},
@@ -238,48 +320,91 @@ class FeelfitUserSensor(CoordinatorEntity, SensorEntity):
             "model": "Feelfit Account",
         }
 
-class FeelfitBirthdaySensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str, attr_key: str, name: str):
-        CoordinatorEntity.__init__(self, coordinator)
+class FeelfitBirthdaySensor(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], SensorEntity):
+    """Sensor for birthday with date formatting."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
+        entry_id: str,
+        attr_key: str,
+        name: str,
+        profile_user_id: str | None = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
         self._entry_id = entry_id
         self._attr_key = attr_key
         self._name = name
-        self._unique_id = f"{entry_id}_{attr_key}"
+        self._profile_user_id = profile_user_id
+
+        self._unique_id = f"{entry_id}_{attr_key}_{profile_user_id or 'primary'}"
         self._attr_translation_key = attr_key
         self._attr_has_entity_name = True
 
     @property
     def unique_id(self) -> str:
+        """Return unique ID."""
         return self._unique_id
 
-    # @property
-    # def name(self) -> str:
-        # return f"Feelfit {self._name}"
-
     @property
-    def native_value(self):
-        user_info = (self.coordinator.data or {}).get("user_info") or {}
+    def native_value(self) -> str | None:
+        """Return formatted birthday."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_info = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_info = profile_info
+                user_settings = profile_data.get("user_settings") or {}
+                break
+
+        if not user_info and profiles:
+            user_info = profiles[0].get("user_info") or {}
+            user_settings = profiles[0].get("user_settings") or {}
+        elif not user_info:
+            return None
+
         raw = user_info.get("birthday")
-        user_settings = (self.coordinator.data or {}).get("user_settings") or {}
         fmt = user_settings.get("date_format")
         return _format_birthday(raw, fmt)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        return {"source": "feelfit", "attribute": self._attr_key, "date_format": (self.coordinator.data or {}).get("user_settings", {}).get("date_format")}
+        """Return extra attributes."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_settings = {}
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_settings = profile_data.get("user_settings") or {}
+                break
+
+        return {
+            "source": "feelfit",
+            "attribute": self._attr_key,
+            "date_format": user_settings.get("date_format"),
+        }
 
     @property
-    def device_info(self):
-        # user_info = (self.coordinator.data or {}).get("user_info") or {}
-        # user_id = user_info.get("user_id")
-        # name = user_info.get("account_name") or f"Feelfit User {user_id or self._entry_id}"
-        # return {
-            # "identifiers": {(DOMAIN, user_id or self._entry_id)},
-            # "name": name,
-            # "manufacturer": "Feelfit",
-            # "model": "Feelfit Account",
-        # }
-        user_info = (self.coordinator.data or {}).get("user_info") or {}
+    def device_info(self) -> dict[str, Any]:
+        """Return device info."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_info = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_info = profile_info
+                break
+
+        if not user_info and profiles:
+            user_info = profiles[0].get("user_info") or {}
+
+        if not user_info:
+            user_info = {}
         user_id = user_info.get("user_id") or self._entry_id
         return {
             "identifiers": {(DOMAIN, f"user_{user_id}")},
@@ -288,45 +413,86 @@ class FeelfitBirthdaySensor(CoordinatorEntity, SensorEntity):
             "model": "Feelfit Account",
         }
 
-class FeelfitGoalSensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str, unique_key: str, name: str, unit: str | None, goal_type: str):
-        CoordinatorEntity.__init__(self, coordinator)
+class FeelfitGoalSensor(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], SensorEntity):
+    """Sensor for goal values."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
+        entry_id: str,
+        unique_key: str,
+        name: str,
+        unit: str | None,
+        goal_type: str,
+        profile_user_id: str | None = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
         self._entry_id = entry_id
-        self._unique_id = f"{entry_id}_{unique_key}"
+
+        self._unique_id = f"{entry_id}_{unique_key}_{profile_user_id or 'primary'}"
         self._name = name
         self._unit = unit
         self._goal_type = goal_type
+        self._profile_user_id = profile_user_id
         self._attr_translation_key = unique_key
         self._attr_has_entity_name = True
 
     @property
     def unique_id(self) -> str:
+        """Return unique ID."""
         return self._unique_id
 
-    # @property
-    # def name(self) -> str:
-        # return f"Feelfit {self._name}"
-
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str | None:
+        """Return unit of measurement."""
         return self._unit
 
     @property
-    def native_value(self):
-        goals_payload = (self.coordinator.data or {}).get("goals") or {}
-        goals_list = goals_payload.get("goals") or []
+    def native_value(self) -> Any:
+        """Return goal value."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        goals_list = []
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                goals_payload = profile_data.get("goals") or {}
+                goals_list = goals_payload.get("goals") or []
+                break
+
+        if not goals_list and profiles:
+            goals_payload = profiles[0].get("goals") or {}
+            goals_list = goals_payload.get("goals") or []
+
         for g in goals_list:
             if g.get("goal_type") == self._goal_type:
                 return g.get("goal_value")
         return None
 
     @property
-    def device_info(self):
-        # user_info = (self.coordinator.data or {}).get("user_info") or {}
-        # user_id = user_info.get("user_id")
-        # name = user_info.get("account_name") or f"Feelfit User {user_id or self._entry_id}"
-        # return {"identifiers": {(DOMAIN, user_id or self._entry_id)}, "name": name, "manufacturer": "Feelfit", "model": "Feelfit Goals"}
-        user_info = (self.coordinator.data or {}).get("user_info") or {}
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra attributes."""
+        return {"source": "feelfit", "goal_type": self._goal_type}
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device info."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_info = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_info = profile_info
+                break
+
+        if not user_info and profiles:
+            user_info = profiles[0].get("user_info") or {}
+
+        if not user_info:
+            user_info = {}
+
         user_id = user_info.get("user_id") or self._entry_id
         return {
             "identifiers": {(DOMAIN, f"user_{user_id}")},
@@ -335,9 +501,20 @@ class FeelfitGoalSensor(CoordinatorEntity, SensorEntity):
             "model": "Feelfit Account",
         }
 
-class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str, unique_key: str, name: str, unit: str | None, device_index: int = 0):
-        CoordinatorEntity.__init__(self, coordinator)
+class FeelfitDeviceSensor(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], SensorEntity):
+    """Sensor for bound device info."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
+        entry_id: str,
+        unique_key: str,
+        name: str,
+        unit: str | None,
+        device_index: int = 0,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
         self._entry_id = entry_id
         self._device_index = device_index
         self._unique_id = f"{entry_id}_device_{unique_key}"
@@ -346,15 +523,21 @@ class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def unique_id(self) -> str:
+        """Return unique ID."""
         return self._unique_id
 
     @property
     def name(self) -> str:
+        """Return sensor name."""
         return self._name
 
     @property
-    def native_value(self):
-        device_binds = (self.coordinator.data or {}).get("device_binds", {}).get("device_binds") or []
+    def native_value(self) -> str | None:
+        """Return device name."""
+        device_binds = (
+            (self.coordinator.data or {}).get("device_binds", {}).get("device_binds")
+            or []
+        )
         if len(device_binds) > self._device_index:
             d = device_binds[self._device_index]
             return d.get("scale_name") or d.get("internal_model") or d.get("mac")
@@ -362,7 +545,11 @@ class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        device_binds = (self.coordinator.data or {}).get("device_binds", {}).get("device_binds") or []
+        """Return extra attributes."""
+        device_binds = (
+            (self.coordinator.data or {}).get("device_binds", {}).get("device_binds")
+            or []
+        )
         attrs: dict[str, Any] = {}
         if len(device_binds) > self._device_index:
             d = device_binds[self._device_index]
@@ -383,6 +570,7 @@ class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
             ):
                 if key in d:
                     attrs[key] = d.get(key)
+
             model_info = d.get("model_info")
             if isinstance(model_info, dict):
                 for mk, mv in model_info.items():
@@ -399,13 +587,22 @@ class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
     @property
-    def device_info(self):
-        device_binds = (self.coordinator.data or {}).get("device_binds", {}).get("device_binds") or []
+    def device_info(self) -> dict[str, Any]:
+        """Return device info."""
+        device_binds = (
+            (self.coordinator.data or {}).get("device_binds", {}).get("device_binds")
+            or []
+        )
         user_info = (self.coordinator.data or {}).get("user_info") or {}
+
         if len(device_binds) > self._device_index:
             d = device_binds[self._device_index]
-            scale_name = d.get("scale_name") or d.get("internal_model") or f"Device {self._device_index}"
-            brand = d.get("brand_name") or (d.get("model_info") or {}).get("brand_info", {}).get("brand_name")
+            scale_name = (
+                d.get("scale_name") or d.get("internal_model") or f"Device {self._device_index}"
+            )
+            model_info = d.get("model_info") or {}
+            brand_info = model_info.get("brand_info") or {}
+            brand = d.get("brand_name") or brand_info.get("brand_name")
             friendly_name = f"Feelfit {scale_name}"
             if brand:
                 friendly_name = f"{friendly_name} ({brand})"
@@ -414,8 +611,9 @@ class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
                 "identifiers": {(DOMAIN, identifier)},
                 "name": friendly_name,
                 "manufacturer": brand or "Feelfit",
-                "model": (d.get("model_info") or {}).get("model") or d.get("internal_model") or "Feelfit Device",
+                "model": model_info.get("model") or d.get("internal_model") or "Feelfit Device",
             }
+
         user_id = user_info.get("user_id")
         return {
             "identifiers": {(DOMAIN, f"{user_id}_device_{self._device_index}")},
@@ -424,40 +622,65 @@ class FeelfitDeviceSensor(CoordinatorEntity, SensorEntity):
             "model": "Feelfit Device",
         }
 
+class FeelfitMeasurementSensor(CoordinatorEntity[DataUpdateCoordinator[dict[str, Any]]], SensorEntity):
+    """Sensor for measurement values."""
 
-class FeelfitMeasurementSensor(CoordinatorEntity, SensorEntity):
-    """Sensor exposing a single key from the latest measurement, attached to the PERSON."""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, entry_id: str, unique_key: str, name: str, unit: str | None, measurement_key: str):
-        CoordinatorEntity.__init__(self, coordinator)
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
+        entry_id: str,
+        unique_key: str,
+        name: str,
+        unit: str | None,
+        measurement_key: str,
+        profile_user_id: str | None = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
         self._entry_id = entry_id
-        self._unique_id = f"{entry_id}_{unique_key}"
+
+        self._unique_id = f"{entry_id}_{unique_key}_{profile_user_id or 'primary'}"
         self._name = name
         self._unit = unit
         self._measurement_key = measurement_key
-        self._attr_translation_key = "measurement_" + measurement_key
+        self._profile_user_id = profile_user_id
+        self._attr_translation_key = f"measurement_{measurement_key}"
         self._attr_has_entity_name = True
-        
+
     @property
     def unique_id(self) -> str:
+        """Return unique ID."""
         return self._unique_id
 
-    # @property
-    # def name(self) -> str:
-        # return f"{self._name}"
-
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str | None:
+        """Return unit of measurement."""
         return self._unit
 
     @property
-    def native_value(self):
-        measurement = (self.coordinator.data or {}).get("measurements", {}).get("last_measurement")
+    def native_value(self) -> Any:
+        """Return measurement value."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        measurement = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                measurements_payload = profile_data.get("measurements") or {}
+                measurement = measurements_payload.get("last_measurement")
+                break
+
+        if not measurement and profiles:
+            measurements_payload = profiles[0].get("measurements") or {}
+            measurement = measurements_payload.get("last_measurement")
+
         if not measurement:
-            _LOGGER.debug("FeelfitMeasurementSensor: no measurement available for key %s", self._measurement_key)
+            _LOGGER.debug(
+                "FeelfitMeasurementSensor: no measurement for key %s",
+                self._measurement_key,
+            )
             return None
 
-        _LOGGER.debug("FeelfitMeasurementSensor: last_measurement = %s", measurement)
         raw_val = measurement.get(self._measurement_key)
 
         if self._measurement_key == "time_stamp" and raw_val:
@@ -465,34 +688,34 @@ class FeelfitMeasurementSensor(CoordinatorEntity, SensorEntity):
                 ts = int(raw_val)
                 dt = datetime.fromtimestamp(ts)
                 return dt.isoformat()
-            except Exception:
+            except (ValueError, OSError):
                 return str(raw_val)
 
         if isinstance(raw_val, (int, float)):
             if self._measurement_key in ("bodyage", "measurement_id", "user_id"):
                 try:
                     return int(raw_val)
-                except Exception:
+                except (ValueError, TypeError):
                     return raw_val
             try:
                 fval = float(raw_val)
                 if fval.is_integer():
                     return int(fval)
                 return round(fval, 2)
-            except Exception:
+            except (ValueError, TypeError):
                 return raw_val
 
         if isinstance(raw_val, str):
-            if raw_val.replace(".", "", 1).isdigit():
+            cleaned = raw_val.replace(".", "", 1)
+            if cleaned.isdigit() or (cleaned.startswith("-") and cleaned[1:].isdigit()):
                 try:
                     if "." in raw_val:
                         fval = float(raw_val)
                         if fval.is_integer():
                             return int(fval)
                         return round(fval, 2)
-                    else:
-                        return int(raw_val)
-                except Exception:
+                    return int(raw_val)
+                except (ValueError, TypeError):
                     pass
             return raw_val
 
@@ -500,22 +723,55 @@ class FeelfitMeasurementSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        measurement = (self.coordinator.data or {}).get("measurements", {}).get("last_measurement")
+        """Return extra attributes."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        measurement = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                measurements_payload = profile_data.get("measurements") or {}
+                measurement = measurements_payload.get("last_measurement")
+                break
+
+        if not measurement and profiles:
+            measurements_payload = profiles[0].get("measurements") or {}
+            measurement = measurements_payload.get("last_measurement")
+
         attrs: dict[str, Any] = {}
         if measurement:
-            for k in ("measurement_id", "user_id", "scale_name", "internal_model", "mac", "parameter", "accuracy_flag", "measure_mode_flags"):
+            for k in (
+                "measurement_id",
+                "user_id",
+                "scale_name",
+                "internal_model",
+                "mac",
+                "parameter",
+                "accuracy_flag",
+                "measure_mode_flags",
+            ):
                 if k in measurement:
                     attrs[k] = measurement.get(k)
         return attrs
 
     @property
-    def device_info(self):
-        # # attach measurement sensors to person device
-        # user_info = (self.coordinator.data or {}).get("user_info") or {}
-        # user_id = user_info.get("user_id")
-        # name = user_info.get("account_name") or f"Feelfit User {user_id or self._entry_id}"
-        # return {"identifiers": {(DOMAIN, user_id or self._entry_id)}, "name": name, "manufacturer": "Feelfit", "model": "Feelfit Measurement"}
-        user_info = (self.coordinator.data or {}).get("user_info") or {}
+    def device_info(self) -> dict[str, Any]:
+        """Return device info."""
+        profiles = (self.coordinator.data or {}).get("profiles") or []
+
+        user_info = None
+        for profile_data in profiles:
+            profile_info = profile_data.get("user_info") or {}
+            if self._profile_user_id and str(profile_info.get("user_id")) == str(self._profile_user_id):
+                user_info = profile_info
+                break
+
+        if not user_info and profiles:
+            user_info = profiles[0].get("user_info") or {}
+
+        if not user_info:
+            user_info = {}
+
         user_id = user_info.get("user_id") or self._entry_id
         return {
             "identifiers": {(DOMAIN, f"user_{user_id}")},


### PR DESCRIPTION
# Multi-Profile Support for Feelfit Integration

## Overview
This PR adds comprehensive multi-profile support to the Feelfit Home Assistant integration, allowing users to monitor multiple family members from a single Feelfit account.

## Features Added

### 1. **Multi-Profile Selection** 
- During initial setup, users can select which profiles to monitor
- Displays all available profiles with their names 
- Primary profile is pre-selected by default
- Support for up to 5 profiles per account

### 2. **Dynamic Profile Management**
- New **Options Flow** accessible via Settings → Devices → Feelfit → CONFIGURE
- Enable/disable profiles at runtime without removing the integration
- Changes take effect after automatic reload (~10-15 seconds)

### 3. **Automatic Cleanup**
- Devices and entities are automatically removed when profiles are deactivated
- No orphaned entities left behind
- Clean device registry management

### 4. **Enhanced Entity Tracking**
- Entity `unique_id` now includes `profile_user_id` for precise identification
- Format: `{entry_id}_{sensor_key}_{profile_user_id}`
- Enables selective entity removal per profile

## Technical Changes

### Modified Files
- **`config_flow.py`**: Added profile selection step and options flow handler
- **`__init__.py`**: Implemented `async_update_options()` with device registry cleanup
- **`sensor.py`**: Updated all sensor classes to include `profile_user_id` in `unique_id`
- **`api.py`**: No functional changes, code cleanup only
- **`const.py`**: Added `CONF_SELECTED_PROFILES` and `CONF_PROFILES_LIST` constants

### Code Quality
- Removed all inline comments for production readiness
- Maintained docstrings for Home Assistant compatibility
- Full type hints throughout
- Syntax verified for all files

## User Experience

### Setup Flow
1. Enter Feelfit credentials
2. Select profiles to monitor (checkboxes)
3. Integration creates separate devices for each profile

### Runtime Management
1. Navigate to Settings → Devices & Services → Feelfit
2. Click **CONFIGURE** (gear icon)
3. Toggle profile checkboxes
4. Submit → automatic reload
5. Disabled profile devices disappear completely

## Testing
- ✅ Profile selection during setup
- ✅ Multiple profiles active simultaneously
- ✅ Options flow profile activation
- ✅ Options flow profile deactivation
- ✅ Device removal on profile disable
- ✅ Integration reload after options change

## Breaking Changes
**None** - Existing installations will continue to work with the primary profile only. Users must reconfigure to enable multi-profile support.

## Migration Notes
For users who want to use the new entity removal feature:
1. Remove the Feelfit integration completely
2. Restart Home Assistant
3. Re-add the integration
4. Select desired profiles

This ensures all entities have the new `unique_id` format with `profile_user_id`.

## Screenshots

<img width="965" height="290" alt="image" src="https://github.com/user-attachments/assets/7bd53505-174f-4f43-8081-2fab93ccc1c2" />
<img width="2059" height="1408" alt="image" src="https://github.com/user-attachments/assets/b7b86c56-818b-48cd-b538-3701733906e0" />
